### PR TITLE
Feature/remote user header

### DIFF
--- a/cravat_multiuser/__init__.py
+++ b/cravat_multiuser/__init__.py
@@ -678,7 +678,7 @@ async def check_logged (request):
                 days_rem = guest_lifetime - days_passed
             else:
                 days_rem = -1
-        response = {'logged': logged, 'email': email, 'days_rem': days_rem}
+        response = {'logged': logged, 'email': email, 'days_rem': days_rem, 'admin': await is_admin_loggedin(request)}
     else:
         response = 'no multiuser mode'
     return web.json_response(response)

--- a/cravat_multiuser/__init__.py
+++ b/cravat_multiuser/__init__.py
@@ -483,7 +483,6 @@ def create_user_dir_if_not_exist (username):
 
 async def signup (request):
     global servermode
-    global noguest
     if servermode and not enable_remote_user_header:
         queries = request.rel_url.query
         username = queries['username']
@@ -812,11 +811,10 @@ async def setup_module ():
     await admindb.init()
 
 async def get_noguest(request):
-    global noguest
-    noguest = system_conf.get('noguest', True)
     return web.json_response(noguest)
 
 system_conf = au.get_system_conf()
+noguest = system_conf.get('noguest', False)
 enable_remote_user_header = system_conf.get('enable_remote_user_header', False)
 
 def add_routes (router):

--- a/cravat_multiuser/__init__.py
+++ b/cravat_multiuser/__init__.py
@@ -444,6 +444,7 @@ async def try_remote_user_login (request):
             if remote_username:
                 session = await get_session(request)
                 session['username'] = remote_username
+                create_user_dir_if_not_exist(remote_username)
                 sessionkey = get_session_key()
                 session['sessionkey'] = sessionkey
                 await admindb.add_sessionkey(remote_username, sessionkey)

--- a/cravat_multiuser/nocache/cravat_multiuser.css
+++ b/cravat_multiuser/nocache/cravat_multiuser.css
@@ -201,3 +201,12 @@ body {
   align-items: center;
   gap: 0.25rem;
 }
+
+#guestdiv {
+    display: none;
+}
+
+#guestdiv.show {
+    display: block
+}
+

--- a/cravat_multiuser/nocache/cravat_multiuser.js
+++ b/cravat_multiuser/nocache/cravat_multiuser.js
@@ -1,5 +1,6 @@
 adminMode = false;
 noRemDays = null;
+noguest = false
 
 function openSubmitPage () {
     location.href = location.protocol + '//' + window.location.host + '/submit/nocache/index.html';
@@ -215,51 +216,7 @@ function tryAsGuest () {
     var retypepassword = password;
     var question = 'Type 0 as answer';
     var answer = '0';
-    if (username == '' || password == '' || retypepassword == '' || question == '' || answer == '') {
-        msgAccountDiv('Fill all the blanks.');
-        return;
-    }
-    if (password != retypepassword) {
-        msgAccountDiv('Password mismatch');
-        return;
-    }
-    $.ajax({
-        url: '/server/signup',
-        data: {'username': username, 'password': password, 'question': question, 'answer': answer},
-        success: function (response) {
-            if (response == 'already registered') {
-                msgAccountDiv('Something went wrong. Please click the try as guest button again.');
-            } else if (response == 'success') {
-                document.getElementById('login_username').value = username;
-                document.getElementById('login_password').value = password;
-                /*
-                var div = getEl('div');
-                var sdiv = getEl('div');
-                sdiv.textContent = 'SUCCESS!';
-                addEl(div, sdiv);
-                addEl(div, getEl('br'));
-                var sdiv = getEl('div');
-                sdiv.textContent = 'Temporary account has been created for you to try OpenCRAVAT.';
-                addEl(div, sdiv);
-                addEl(div, getEl('br'));
-                var sdiv = getEl('div');
-                sdiv.textContent = 'Username is ' + username;
-                addEl(div, sdiv);
-                var sdiv = getEl('div');
-                sdiv.textContent = 'Password is ' + password;
-                addEl(div, sdiv);
-                addEl(div, getEl('br'));
-                var sdiv = getEl('div');
-                sdiv.textContent = 'Click OK to continue.';
-                addEl(div, sdiv);
-                msgAccountDiv(div, login);
-                */
-                login();
-            } else if (response == 'fail') {
-                msgAccountDiv('Signup failed');
-            }
-        }
-    });
+    processSignup(username, password, retypepassword, question, answer)
 }
 
 function signupSubmit () {
@@ -268,27 +225,48 @@ function signupSubmit () {
     var retypepassword = document.getElementById('signupretypepassword').value.trim();
     var question = document.getElementById('signupquestion').value.trim();
     var answer = document.getElementById('signupanswer').value.trim();
-    if (username == '' || password == '' || retypepassword == '' || question == '' || answer == '') {
-        msgAccountDiv('Fill all the blanks.');
-        return;
+    processSignup(username, password, retypepassword, question, answer)
+}
+
+function processSignup(username, password, retypepassword, question, answer) {
+    if (!username.match(/^\S+@\S+\.\S+$/) && username != "admin" && !username.includes("guest_")) {
+        msgAccountDiv('Invalid email.')
+        return
+    }
+    if (password == '') {
+        msgAccountDiv('Password is empty.')
+        return
+    }
+    if (retypepassword == '') {
+        msgAccountDiv('Re-typed password is empty.')
+        return
+    }
+    if (question == '') {
+        msgAccountDiv('Question is empty.')
+        return
+    }
+    if (answer == '') {
+        msgAccountDiv('Answer is empty.')
+        return
     }
     if (password != retypepassword) {
-        msgAccountDiv('Password mismatch');
+        msgAccountDiv('Password mismatch')
         return;
     }
     $.ajax({
         url: '/server/signup',
         data: {'username': username, 'password': password, 'question': question, 'answer': answer},
         success: function (response) {
-            if (response == 'already registered') {
-                msgAccountDiv('Already registered');
-            } else if (response == 'success') {
+            if (response == 'Signup successful') {
                 document.getElementById('login_username').value = username;
                 document.getElementById('login_password').value = password;
-                msgAccountDiv('Signup successful', login);
-            } else if (response == 'fail') {
-                msgAccountDiv('Signup failed');
+                msgAccountDiv(response, login)
+            } else {
+                msgAccountDiv(response, null)
             }
+        },
+        error: function(response) {
+            msgAccountDiv(response, null)
         }
     });
 }
@@ -978,5 +956,20 @@ function multiuser_run () {
             login();
         }
     });
+}
+
+window.onload = function(evt) {
+    fetch('/server/noguest').then(function(response) {
+        if (response.status != 200) {
+            return false
+        } else {
+            return response.json()
+        }
+    }).then(function(response) {
+        noguest = response
+        if (!noguest) {
+            document.querySelector('#guestdiv').classList.add('show')
+        }
+    })
 }
 

--- a/cravat_multiuser/nocache/cravat_multiuser.js
+++ b/cravat_multiuser/nocache/cravat_multiuser.js
@@ -280,6 +280,7 @@ function checkLogged (inUsername) {
             if (logged == true) {
                 username = response['email'];
                 noRemDays = response['days_rem'];
+                adminMode = response['admin']
                 doAfterLogin(username);
             } else {
                 showUnloggedControl();
@@ -298,8 +299,7 @@ function showUnloggedControl () {
 
 function doAfterLogin (username) {
     showLoggedControl(username);
-    if (username == 'admin') {
-        adminMode = true;
+    if (adminMode == true) {
         setupAdminMode();
     }
     populateJobs();

--- a/cravat_multiuser/nocache/login.html
+++ b/cravat_multiuser/nocache/login.html
@@ -47,8 +47,10 @@
                 Forgot password?</span>
               <span style='font-size: 12px;'>or</span>
               <button onclick='showSignupDiv();'>Sign up</button>
-              <span style='font-size: 12px;'>or</span>
-              <button id='guest_button' onclick='tryAsGuest();' >Try as Guest</button>
+              <div id='guestdiv'
+                  <span style='font-size: 12px;'>or</span>
+                  <button id='guest_button' onclick='tryAsGuest();' >Try as Guest</button>
+              </div>
               <a href='https://open-cravat.readthedocs.io/en/latest/' target='_blank' style='font-size: 11px; color: white; text-decoration: none; cursor: pointer;'>Help</a>
           </div>
           <div id='forgotpassworddiv' style='display: none; margin-top: 15px;'>


### PR DESCRIPTION
Add ability to authenticate users based on a header set by an upstream proxy. This allows the proxy to handle authentication and set a trusted header for the open-cravat application to start a users session. For security reasons network policies should be configured so only traffic passing through the proxy is allow to reach the open-cravat server.

Added a configuration settings for noguest, enable_remote_user_header, remote_user_header and admin_list. 

To enable features update cravat-system.yml:
```
noguest: True # Disable guest account. Default: False
enable_remote_user_header: True # Enable authentication using header with username. Default: False
remote_user_header: remote_user # Name of header that has the username. Default: remote_user 
admin_list: # List of admin usernames. Default: ["admin"]
    - admin1
    - admin2
```